### PR TITLE
Swap to identifying collections by an ID rather than by name

### DIFF
--- a/langconnect/api/collections.py
+++ b/langconnect/api/collections.py
@@ -25,15 +25,8 @@ async def collections_create(
     user: Annotated[AuthenticatedUser, Depends(resolve_user)],
 ):
     """Creates a new PGVector collection by name with optional metadata."""
-    collection_name = collection_data.name
     metadata = collection_data.metadata
-    # TODO(Eugene): Change into a single database call.
-    existing = await get_pgvector_collection_details(user, collection_name)
-    if existing:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=f"Collection '{collection_name}' already exists.",
-        )
+    collection_name = collection_data.name
     await create_pgvector_collection(user, collection_name, metadata)
     created_collection = await get_pgvector_collection_details(user, collection_name)
     if not created_collection:
@@ -50,45 +43,45 @@ async def collections_list(user: Annotated[AuthenticatedUser, Depends(resolve_us
     return [CollectionResponse(**c) for c in collections]
 
 
-@router.get("/{collection_name}", response_model=CollectionResponse)
+@router.get("/{collection_id}", response_model=CollectionResponse)
 async def collections_get(
     user: Annotated[AuthenticatedUser, Depends(resolve_user)],
-    collection_name: str,
+    collection_id: str,
 ):
     """Retrieves details (name and UUID) of a specific PGVector collection."""
-    collection = await get_pgvector_collection_details(user, collection_name)
+    collection = await get_pgvector_collection_details(user, collection_id)
     if not collection:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Collection '{collection_name}' not found",
+            detail=f"Collection '{collection_id}' not found",
         )
     return CollectionResponse(**collection)
 
 
-@router.delete("/{collection_name}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/{collection_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def collections_delete(
     user: Annotated[AuthenticatedUser, Depends(resolve_user)],
-    collection_name: str,
+    collection_id: str,
 ):
     """Deletes a specific PGVector collection by name."""
-    await delete_pgvector_collection(user, collection_name)
+    await delete_pgvector_collection(user, collection_id)
     return HTTPException(
         status_code=status.HTTP_204_NO_CONTENT,
-        detail=f"Collection '{collection_name}' deleted successfully.",
+        detail=f"Collection '{collection_id}' deleted successfully.",
     )
 
 
-@router.patch("/{collection_name}", response_model=CollectionResponse)
+@router.patch("/{collection_id}", response_model=CollectionResponse)
 async def collections_update(
     user: Annotated[AuthenticatedUser, Depends(resolve_user)],
-    collection_name: str,
+    collection_id: str,
     collection_data: CollectionUpdate,
 ):
     """Updates a specific PGVector collection's name and/or metadata."""
     # Update the collection
     updated_collection = await update_pgvector_collection(
         user,
-        collection_name=collection_name,
+        collection_id=collection_id,
         new_name=collection_data.name,
         metadata=collection_data.metadata,
     )
@@ -96,7 +89,7 @@ async def collections_update(
     if not updated_collection:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Failed to update collection '{collection_name}'",
+            detail=f"Failed to update collection '{collection_id}'",
         )
 
     return CollectionResponse(**updated_collection)

--- a/langconnect/api/collections.py
+++ b/langconnect/api/collections.py
@@ -1,4 +1,5 @@
 from typing import Annotated
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
@@ -6,7 +7,8 @@ from langconnect.auth import AuthenticatedUser, resolve_user
 from langconnect.database import (
     create_pgvector_collection,
     delete_pgvector_collection,
-    get_pgvector_collection_details,
+    get_collection_by_id,
+    get_collection_by_name,
     list_pgvector_collections,
     update_pgvector_collection,
 )
@@ -27,13 +29,20 @@ async def collections_create(
     """Creates a new PGVector collection by name with optional metadata."""
     metadata = collection_data.metadata
     collection_name = collection_data.name
+    # TODO(Eugene): Remove all the unnecessary requests.
+    collection_info = await get_collection_by_name(user, collection_name)
+    if collection_info:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Collection '{collection_name}' already exists.",
+        )
     await create_pgvector_collection(user, collection_name, metadata)
-    created_collection = await get_pgvector_collection_details(user, collection_name)
-    if not created_collection:
+    collection_info = await get_collection_by_name(user, collection_name)
+    if not collection_info:
         raise HTTPException(
             status_code=500, detail="Failed to retrieve collection after creation"
         )
-    return CollectionResponse(**created_collection)
+    return CollectionResponse(**collection_info)
 
 
 @router.get("", response_model=list[CollectionResponse])
@@ -46,10 +55,10 @@ async def collections_list(user: Annotated[AuthenticatedUser, Depends(resolve_us
 @router.get("/{collection_id}", response_model=CollectionResponse)
 async def collections_get(
     user: Annotated[AuthenticatedUser, Depends(resolve_user)],
-    collection_id: str,
+    collection_id: UUID,
 ):
     """Retrieves details (name and UUID) of a specific PGVector collection."""
-    collection = await get_pgvector_collection_details(user, collection_id)
+    collection = await get_collection_by_id(user, str(collection_id))
     if not collection:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -61,10 +70,10 @@ async def collections_get(
 @router.delete("/{collection_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def collections_delete(
     user: Annotated[AuthenticatedUser, Depends(resolve_user)],
-    collection_id: str,
+    collection_id: UUID,
 ):
     """Deletes a specific PGVector collection by name."""
-    await delete_pgvector_collection(user, collection_id)
+    await delete_pgvector_collection(user, str(collection_id))
     return HTTPException(
         status_code=status.HTTP_204_NO_CONTENT,
         detail=f"Collection '{collection_id}' deleted successfully.",
@@ -74,14 +83,14 @@ async def collections_delete(
 @router.patch("/{collection_id}", response_model=CollectionResponse)
 async def collections_update(
     user: Annotated[AuthenticatedUser, Depends(resolve_user)],
-    collection_id: str,
+    collection_id: UUID,
     collection_data: CollectionUpdate,
 ):
     """Updates a specific PGVector collection's name and/or metadata."""
     # Update the collection
     updated_collection = await update_pgvector_collection(
         user,
-        collection_id=collection_id,
+        collection_id=str(collection_id),
         new_name=collection_data.name,
         metadata=collection_data.metadata,
     )

--- a/langconnect/api/documents.py
+++ b/langconnect/api/documents.py
@@ -21,15 +21,15 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["documents"])
 
 
-@router.post("/collections/{collection_name}/documents", response_model=dict[str, Any])
+@router.post("/collections/{collection_id}/documents", response_model=dict[str, Any])
 async def documents_create(
     user: Annotated[AuthenticatedUser, Depends(resolve_user)],
-    collection_name: str,
+    collection_id: str,
     files: list[UploadFile] = File(...),
     metadatas_json: str | None = Form(None),
 ):
     """Processes and indexes (adds) new document files with optional metadata."""
-    collection = await get_pgvector_collection_details(user, collection_name)
+    collection = await get_pgvector_collection_details(user, collection_id)
     if not collection:
         raise HTTPException(status_code=404, detail="Collection not found")
 
@@ -99,7 +99,7 @@ async def documents_create(
     # but maybe inform the user about the failures.
     try:
         added_ids = await add_documents_to_vectorstore(
-            user, collection_name, all_langchain_docs
+            user, collection_id, all_langchain_docs
         )
         if not added_ids:
             # This might indicate a problem with the vector store itself
@@ -137,17 +137,17 @@ async def documents_create(
 
 
 @router.get(
-    "/collections/{collection_name}/documents", response_model=list[DocumentResponse]
+    "/collections/{collection_id}/documents", response_model=list[DocumentResponse]
 )
 async def documents_list(
     user: Annotated[AuthenticatedUser, Depends(resolve_user)],
-    collection_name: str,
+    collection_id: str,
     limit: int = Query(10, ge=1, le=100),
     offset: int = Query(0, ge=0),
 ):
     """Lists documents within a specific collection."""
     results = await list_documents_in_vectorstore(
-        user, collection_name, limit=limit, offset=offset
+        user, collection_id, limit=limit, offset=offset
     )
     if results is None:
         raise HTTPException(status_code=404, detail="No such collection.")
@@ -155,17 +155,17 @@ async def documents_list(
 
 
 @router.delete(
-    "/collections/{collection_name}/documents/{document_id}",
+    "/collections/{collection_id}/documents/{document_id}",
     response_model=dict[str, bool],
 )
 async def documents_delete(
     user: Annotated[AuthenticatedUser, Depends(resolve_user)],
-    collection_name: str,
+    collection_id: str,
     document_id: str,
 ):
     """Deletes a specific document from a collection by its ID."""
     success = await delete_documents_from_vectorstore(
-        user, collection_name, [document_id]
+        user, collection_id, [document_id]
     )
     if not success:
         raise HTTPException(status_code=404, detail="Failed to delete document.")
@@ -174,11 +174,11 @@ async def documents_delete(
 
 
 @router.post(
-    "/collections/{collection_name}/documents/search", response_model=list[SearchResult]
+    "/collections/{collection_id}/documents/search", response_model=list[SearchResult]
 )
 async def documents_search(
     user: Annotated[AuthenticatedUser, Depends(resolve_user)],
-    collection_name: str,
+    collection_id: str,
     search_query: SearchQuery,
 ):
     """Search for documents within a specific collection."""
@@ -187,7 +187,7 @@ async def documents_search(
 
     results = await search_documents_in_vectorstore(
         user,
-        collection_name,
+        collection_id,
         query=search_query.query,
         limit=search_query.limit or 10,
     )

--- a/langconnect/config.py
+++ b/langconnect/config.py
@@ -4,6 +4,7 @@ from starlette.config import Config, undefined
 env = Config()
 
 IS_TESTING = env("IS_TESTING", cast=str, default="").lower() == "true"
+IS_TESTING = True
 
 if IS_TESTING:
     SUPABASE_URL = ""

--- a/langconnect/config.py
+++ b/langconnect/config.py
@@ -4,7 +4,6 @@ from starlette.config import Config, undefined
 env = Config()
 
 IS_TESTING = env("IS_TESTING", cast=str, default="").lower() == "true"
-IS_TESTING = True
 
 if IS_TESTING:
     SUPABASE_URL = ""

--- a/langconnect/database/__init__.py
+++ b/langconnect/database/__init__.py
@@ -1,7 +1,8 @@
 from langconnect.database.collections import (
     create_pgvector_collection,
     delete_pgvector_collection,
-    get_pgvector_collection_details,
+    get_collection_by_id,
+    get_collection_by_name,
     list_pgvector_collections,
     update_pgvector_collection,
 )
@@ -9,7 +10,7 @@ from langconnect.database.connection import get_db_connection, get_vectorstore
 from langconnect.database.documents import (
     add_documents_to_vectorstore,
     delete_documents_from_vectorstore,
-    get_document_from_vectorstore,
+    get_document,
     list_documents_in_vectorstore,
     search_documents_in_vectorstore,
 )
@@ -19,9 +20,10 @@ __all__ = [
     "create_pgvector_collection",
     "delete_documents_from_vectorstore",
     "delete_pgvector_collection",
+    "get_collection_by_id",
+    "get_collection_by_name",
     "get_db_connection",
-    "get_document_from_vectorstore",
-    "get_pgvector_collection_details",
+    "get_document",
     "get_vectorstore",
     "list_documents_in_vectorstore",
     "list_pgvector_collections",

--- a/tests/unit_tests/test_collections_api.py
+++ b/tests/unit_tests/test_collections_api.py
@@ -39,9 +39,9 @@ async def test_create_and_get_collection() -> None:
         assert data["name"] == "test_collection"
         assert isinstance(UUID(data["uuid"]), UUID)
 
-        # Get collection by name
+        # Get collection by ID
         get_response = await client.get(
-            f"/collections/{data['name']}", headers=USER_1_HEADERS
+            f"/collections/{data['uuid']}", headers=USER_1_HEADERS
         )
         assert get_response.status_code == 200
         assert get_response.json()["uuid"] == data["uuid"]
@@ -128,16 +128,23 @@ async def test_delete_collection_and_nonexistent() -> None:
         r1 = await client.post("/collections", json=payload, headers=USER_1_HEADERS)
         assert r1.status_code == 201
 
-        # delete it
-        r2 = await client.delete("/collections/to_delete", headers=USER_1_HEADERS)
+        # Get the UUID first
+        get_collection = await client.get("/collections", headers=USER_1_HEADERS)
+        assert get_collection.status_code == 200
+        collections = get_collection.json()
+        collection_id = next((c["uuid"] for c in collections if c["name"] == "to_delete"), None)
+        assert collection_id is not None
+        
+        # delete it by ID
+        r2 = await client.delete(f"/collections/{collection_id}", headers=USER_1_HEADERS)
         assert r2.status_code == 204
 
-        # Try to get it again
-        r3 = await client.get("/collections/to_delete", headers=USER_1_HEADERS)
+        # Try to get it again by ID
+        r3 = await client.get(f"/collections/{collection_id}", headers=USER_1_HEADERS)
         assert r3.status_code == 404
 
         # Deletion is idempotent
-        r4 = await client.delete("/collections/to_delete", headers=USER_1_HEADERS)
+        r4 = await client.delete(f"/collections/{collection_id}", headers=USER_1_HEADERS)
         assert r4.status_code == 204
 
 
@@ -157,9 +164,16 @@ async def test_patch_collection() -> None:
             },
         }
 
-        # update metadata
+        # Get the UUID for colA
+        get_collection = await client.get("/collections", headers=USER_1_HEADERS)
+        assert get_collection.status_code == 200
+        collections = get_collection.json()
+        collection_id = next((c["uuid"] for c in collections if c["name"] == "colA"), None)
+        assert collection_id is not None
+        
+        # update metadata using the UUID
         r2 = await client.patch(
-            "/collections/colA",
+            f"/collections/{collection_id}",
             json={"metadata": {"a": 2}},
             headers=USER_1_HEADERS,
         )
@@ -192,17 +206,24 @@ async def test_update_collection_name_and_metadata() -> None:
             headers=USER_1_HEADERS,
         )
 
+        # Get the UUID for colA
+        get_collection = await client.get("/collections", headers=USER_1_HEADERS)
+        assert get_collection.status_code == 200
+        collections = get_collection.json()
+        colA_id = next((c["uuid"] for c in collections if c["name"] == "colA"), None)
+        assert colA_id is not None
+        
         # try renaming colA to colB (conflict)
         conflict = await client.patch(
-            "/collections/colA",
+            f"/collections/{colA_id}",
             json={"name": "colB"},
             headers=USER_1_HEADERS,
         )
         assert conflict.status_code == 409
 
-        # rename colA to colC with new metadata
+        # rename colA to colC with new metadata (using the UUID we got earlier)
         update = await client.patch(
-            "/collections/colA",
+            f"/collections/{colA_id}",
             json={"name": "colC", "metadata": {"x": "y"}},
             headers=USER_1_HEADERS,
         )
@@ -213,17 +234,22 @@ async def test_update_collection_name_and_metadata() -> None:
             "name": "colC",
             "metadata": {"x": "y"},
         }
-        # ensure old name is gone
-        get_old = await client.get("/collections/colA")
+        # ensure old name is gone when querying by old name as ID
+        get_old = await client.get(f"/collections/colA")
         assert get_old.status_code == 404
-        # ensure new name works
-        get_new = await client.get("/collections/colC")
+        # ensure we can get by the ID
+        get_by_id = await client.get(f"/collections/{colA_id}", headers=USER_1_HEADERS)
+        assert get_by_id.status_code == 200
+        # the ID should remain the same even though name changed
+        assert get_by_id.json()["uuid"] == colA_id
+        assert get_by_id.json()["name"] == "colC"
         assert get_new.status_code == 200
 
-        # update metadata only on colC
+        # update metadata only on colC using the same ID
         meta_update = await client.patch(
-            "/collections/colC",
+            f"/collections/{colA_id}",
             json={"metadata": {"foo": "bar"}},
+            headers=USER_1_HEADERS,
         )
         assert meta_update.status_code == 200
         assert meta_update.json() == {
@@ -279,12 +305,19 @@ async def test_ownership() -> None:
         r = await client.post("/collections", json=payload, headers=USER_1_HEADERS)
         assert r.status_code == 201
 
-        # user 2 tries to get it
-        r2 = await client.get("/collections/owned_by_user1", headers=USER_2_HEADERS)
+        # Get the UUID of the collection
+        get_response = await client.get("/collections", headers=USER_1_HEADERS)
+        assert get_response.status_code == 200
+        collections = get_response.json()
+        collection_id = next((c["uuid"] for c in collections if c["name"] == "owned_by_user1"), None)
+        assert collection_id is not None
+        
+        # user 2 tries to get it by ID
+        r2 = await client.get(f"/collections/{collection_id}", headers=USER_2_HEADERS)
         assert r2.status_code == 404
 
         # Always ack with 204 for idempotency
-        r3 = await client.delete("/collections/owned_by_user1", headers=USER_2_HEADERS)
+        r3 = await client.delete(f"/collections/{collection_id}", headers=USER_2_HEADERS)
         assert r3.status_code == 204
 
         # Try listing collections as user 2
@@ -294,12 +327,12 @@ async def test_ownership() -> None:
 
         # Try patching the collection as user 2
         r4 = await client.patch(
-            "/collections/owned_by_user1",
+            f"/collections/{collection_id}",
             json={"name": "new_name"},
             headers=USER_2_HEADERS,
         )
         assert r4.status_code == 404
 
         # user 1 can delete it
-        r5 = await client.delete("/collections/owned_by_user1", headers=USER_1_HEADERS)
+        r5 = await client.delete(f"/collections/{collection_id}", headers=USER_1_HEADERS)
         assert r5.status_code == 204

--- a/tests/unit_tests/test_documents_api.py
+++ b/tests/unit_tests/test_documents_api.py
@@ -482,11 +482,14 @@ async def test_documents_create_ownership_validation():
     async with get_async_test_client() as client:
         # Create a collection as USER_1
         collection_name = "doc_test_ownership"
-        await client.post(
+        collection_response = await client.post(
             "/collections",
             json={"name": collection_name, "metadata": {}},
             headers=USER_1_HEADERS,
         )
+        assert collection_response.status_code == 201
+        collection_data = collection_response.json()
+        collection_id = collection_data["uuid"]
 
         # Prepare a file
         file_content = b"This is a test document for ownership validation."
@@ -494,7 +497,7 @@ async def test_documents_create_ownership_validation():
 
         # Try to create document as USER_2
         response = await client.post(
-            f"/collections/{collection_name}/documents",
+            f"/collections/{collection_id}/documents",
             files=files,
             headers=USER_2_HEADERS,
         )

--- a/tests/unit_tests/test_documents_api.py
+++ b/tests/unit_tests/test_documents_api.py
@@ -117,7 +117,7 @@ async def test_documents_create_with_invalid_metadata_json() -> None:
         assert collection_response.status_code == 201
         collection_data = collection_response.json()
         collection_id = collection_data["uuid"]
-        
+
         # Prepare file
         file_content = b"Sample"
         files = [("files", ("a.txt", file_content, "text/plain"))]
@@ -145,7 +145,7 @@ async def test_documents_search_empty_query() -> None:
         assert collection_response.status_code == 201
         collection_data = collection_response.json()
         collection_id = collection_data["uuid"]
-        
+
         # Attempt search with empty query
         resp = await client.post(
             f"/collections/{collection_id}/documents/search",
@@ -160,8 +160,9 @@ async def test_documents_in_nonexistent_collection() -> None:
     """Test operations on documents in a non-existent collection."""
     async with get_async_test_client() as client:
         # Try listing documents in missing collection
+        no_such_collection = "12345678-1234-5678-1234-567812345678"
         response = await client.get(
-            "/collections/no_such_col/documents", headers=USER_1_HEADERS
+            f"/collections/{no_such_collection}/documents", headers=USER_1_HEADERS
         )
         assert response.status_code == 404
 
@@ -169,7 +170,7 @@ async def test_documents_in_nonexistent_collection() -> None:
         file_content = b"X"
         files = [("files", ("x.txt", file_content, "text/plain"))]
         upload_resp = await client.post(
-            "/collections/no_such_col/documents",
+            f"/collections/{no_such_collection}/documents",
             files=files,
             headers=USER_1_HEADERS,
         )
@@ -178,13 +179,14 @@ async def test_documents_in_nonexistent_collection() -> None:
 
         # Try deleting from missing collection/document
         del_resp = await client.delete(
-            "/collections/no_such_col/documents/abcdef", headers=USER_1_HEADERS
+            f"/collections/{no_such_collection}/documents/abcdef",
+            headers=USER_1_HEADERS,
         )
         assert del_resp.status_code == 404
 
         # Try search in missing collection
         search_resp = await client.post(
-            "/collections/no_such_col/documents/search",
+            f"/collections/{no_such_collection}/documents/search",
             json={"query": "foo"},
             headers=USER_1_HEADERS,
         )
@@ -381,8 +383,9 @@ async def test_documents_create_with_non_existent_collection() -> None:
         files = [("files", ("nonexistent.txt", file_content, "text/plain"))]
 
         # Try to create document in a non-existent collection
+        uuid = "12345678-1234-5678-1234-567812345678"
         response = await client.post(
-            "/collections/non_existent_collection/documents",
+            f"/collections/{uuid}/documents",
             files=files,
             headers=USER_1_HEADERS,
         )


### PR DESCRIPTION
* Collections are identified by an ID rather than by name.
* We can make the IDs human readable later on if we need to. For now just stick with UUIDs.
* Requires matching changes on the UI.