### PR TITLE
store name in metadata for now

### DIFF
--- a/langconnect/api/collections.py
+++ b/langconnect/api/collections.py
@@ -69,7 +69,7 @@ async def collections_update(
     updated_collection = await COLLECTIONS.update(
         user.identity,
         str(collection_id),
-        new_name=collection_data.name,
+        name=collection_data.name,
         metadata=collection_data.metadata,
     )
 

--- a/langconnect/api/documents.py
+++ b/langconnect/api/documents.py
@@ -100,7 +100,7 @@ async def documents_create(
     # but maybe inform the user about the failures.
     try:
         added_ids = await add_documents_to_vectorstore(
-            user, str(collection_id), collection["name"], all_langchain_docs
+            collection["table_id"], all_langchain_docs
         )
 
         if not added_ids:

--- a/langconnect/database/collections.py
+++ b/langconnect/database/collections.py
@@ -1,6 +1,7 @@
 import json
 import logging
-from typing import Any, Optional, TypedDict
+import uuid
+from typing import Any, NotRequired, Optional, TypedDict
 
 from fastapi import status
 from fastapi.exceptions import HTTPException
@@ -16,6 +17,8 @@ class CollectionDetails(TypedDict):
     uuid: str
     name: str
     metadata: dict[str, Any]
+    # Temporary field used internally to work-around an issue with PGVector
+    table_id: NotRequired[str]
 
 
 class Collections:
@@ -25,25 +28,30 @@ class Collections:
         self,
         user_id: str,
     ) -> list[CollectionDetails]:
-        """List all collections owned by the given user, ordered by name."""
+        """List all collections owned by the given user, ordered by logical name."""
         async with get_db_connection() as conn:
             records = await conn.fetch(
                 """
-                SELECT uuid, name, cmetadata
-                  FROM langchain_pg_collection
-                 WHERE cmetadata->>'owner_id' = $1
-              ORDER BY name;
+                SELECT uuid, cmetadata
+                FROM langchain_pg_collection
+                WHERE cmetadata->>'owner_id' = $1
+                ORDER BY cmetadata->>'name';
                 """,
                 user_id,
             )
-        return [
-            {
-                "uuid": str(r["uuid"]),
-                "name": r["name"],
-                "metadata": json.loads(r["cmetadata"]),
-            }
-            for r in records
-        ]
+
+        result: list[CollectionDetails] = []
+        for r in records:
+            metadata = json.loads(r["cmetadata"])
+            name = metadata.pop("name", "Unnamed")
+            result.append(
+                {
+                    "uuid": str(r["uuid"]),
+                    "name": name,
+                    "metadata": metadata,
+                }
+            )
+        return result
 
     async def get(
         self,
@@ -62,12 +70,17 @@ class Collections:
                 collection_id,
                 user_id,
             )
+
         if not rec:
             return None
+
+        metadata = json.loads(rec["cmetadata"])
+        name = metadata.pop("name", "Unnamed")
         return {
             "uuid": str(rec["uuid"]),
-            "name": rec["name"],
-            "metadata": json.loads(rec["cmetadata"]),
+            "name": name,
+            "metadata": metadata,
+            "table_id": rec["name"],
         }
 
     async def create(
@@ -87,65 +100,126 @@ class Collections:
             Details of the created collection or None if creation failed.
         """
         # check for existing name
-        existing = await self._get_by_name(user_id, collection_name)
-        if existing:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=f"Collection '{collection_name}' already exists.",
-            )
-
         metadata = metadata.copy() if metadata else {}
         metadata["owner_id"] = user_id
+        metadata["name"] = collection_name
+
+        # For now just assign a random table id
+        table_id = str(uuid.uuid4())
 
         # triggers PGVector to create both the vectorstore and DB entry
-        get_vectorstore(collection_name, collection_metadata=metadata)
+        get_vectorstore(table_id, collection_metadata=metadata)
 
-        # fetch the newly created one
-        created = await self._get_by_name(user_id, collection_name)
-        return created
+        # Fetch the newly created table.
+        async with get_db_connection() as conn:
+            rec = await conn.fetchrow(
+                """
+                SELECT uuid, name, cmetadata
+                  FROM langchain_pg_collection
+                 WHERE name = $1
+                   AND cmetadata->>'owner_id' = $2;
+                """,
+                table_id,
+                user_id,
+            )
+        if not rec:
+            return None
+        metadata = json.loads(rec["cmetadata"])
+        name = metadata.pop("name")
+        return {"uuid": str(rec["uuid"]), "name": name, "metadata": metadata}
 
     async def update(
         self,
         user_id: str,
         collection_id: str,
-        new_name: Optional[str] = None,
+        *,
+        name: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
     ) -> CollectionDetails:
-        """Rename and/or repopulate metadata of an existing collection.
-        Raises 404 if no such collection.
+        """Update collection metadata.
+
+        Four cases:
+
+        1) metadata only          → merge in metadata, keep old JSON->'name'
+        2) metadata + new name    → merge metadata (including new 'name')
+        3) new name only          → jsonb_set the 'name' key
+        4) neither                → no-op, just fetch & return
         """
-        if metadata is not None:
-            metadata = metadata.copy()
-            metadata["owner_id"] = user_id
-
-        metadata_json = json.dumps(metadata) if metadata is not None else None
-
-        async with get_db_connection() as conn:
-            rec = await conn.fetchrow(
-                """
-                UPDATE langchain_pg_collection
-                   SET name      = COALESCE($1, name),
-                       cmetadata = COALESCE($2::json, cmetadata)
-                 WHERE uuid = $3
-                   AND cmetadata->>'owner_id' = $4
-              RETURNING uuid, name, cmetadata;
-                """,
-                new_name,
-                metadata_json,
-                collection_id,
-                user_id,
+        # Case 4: no-op
+        if metadata is None and name is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Must update at least 1 attribute.",
             )
+
+        # Case 1 & 2: metadata supplied (with or without new name)
+        if metadata is not None:
+            # merge in owner_id + optional new name
+            merged = metadata.copy()
+            merged["owner_id"] = user_id
+
+            if name is not None:
+                merged["name"] = name
+            else:
+                # pull existing friendly name so we don't lose it
+                existing = await self.get(user_id, collection_id)
+                if not existing:
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND,
+                        detail=f"Collection '{collection_id}' not found or not owned by you.",
+                    )
+                merged["name"] = existing["name"]
+
+            metadata_json = json.dumps(merged)
+
+            async with get_db_connection() as conn:
+                rec = await conn.fetchrow(
+                    """
+                    UPDATE langchain_pg_collection
+                       SET cmetadata = $1::jsonb
+                     WHERE uuid = $2
+                       AND cmetadata->>'owner_id' = $3
+                    RETURNING uuid, cmetadata;
+                    """,
+                    metadata_json,
+                    collection_id,
+                    user_id,
+                )
+
+        # Case 3: name only
+        else:  # metadata is None but name is not None
+            async with get_db_connection() as conn:
+                rec = await conn.fetchrow(
+                    """
+                    UPDATE langchain_pg_collection
+                       SET cmetadata = jsonb_set(
+                             cmetadata::jsonb,
+                             '{name}',
+                             to_jsonb($1::text),
+                             true
+                           )
+                     WHERE uuid = $2
+                       AND cmetadata->>'owner_id' = $3
+                    RETURNING uuid, cmetadata;
+                    """,
+                    name,
+                    collection_id,
+                    user_id,
+                )
 
         if not rec:
             raise HTTPException(
-                status_code=404,
+                status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Collection '{collection_id}' not found or not owned by you.",
             )
 
+        full_meta = json.loads(rec["cmetadata"])
+        friendly_name = full_meta.pop("name", "Unnamed")
+
         return {
             "uuid": str(rec["uuid"]),
-            "name": rec["name"],
-            "metadata": json.loads(rec["cmetadata"]),
+            "name": friendly_name,
+            "metadata": full_meta,
         }
 
     async def delete(
@@ -168,31 +242,6 @@ class Collections:
                 user_id,
             )
         return int(result.split()[-1])
-
-    async def _get_by_name(
-        self,
-        user_id: str,
-        collection_name: str,
-    ) -> Optional[CollectionDetails]:
-        """Return details if a named collection exists, else None."""
-        async with get_db_connection() as conn:
-            rec = await conn.fetchrow(
-                """
-                SELECT uuid, name, cmetadata
-                  FROM langchain_pg_collection
-                 WHERE name = $1
-                   AND cmetadata->>'owner_id' = $2;
-                """,
-                collection_name,
-                user_id,
-            )
-        if not rec:
-            return None
-        return {
-            "uuid": str(rec["uuid"]),
-            "name": rec["name"],
-            "metadata": json.loads(rec["cmetadata"]),
-        }
 
 
 # Singleton collections object.

--- a/langconnect/database/documents.py
+++ b/langconnect/database/documents.py
@@ -18,8 +18,6 @@ logger = logging.getLogger(__name__)
 
 
 async def add_documents_to_vectorstore(
-    user: AuthenticatedUser,
-    collection_id: str,
     collection_name: str,
     documents: list[Document],
 ) -> list[str]:

--- a/langconnect/database/documents.py
+++ b/langconnect/database/documents.py
@@ -252,7 +252,7 @@ async def search_documents_in_vectorstore(
             detail=f"Collection '{collection_id}' not found or not owned by you.",
         )
     store = get_vectorstore(
-        collection_name=collection_details["name"],
+        collection_name=collection_details["table_id"],
     )
 
     results_with_scores = store.similarity_search_with_score(query, k=limit)

--- a/tests/unit_tests/test_collections_api.py
+++ b/tests/unit_tests/test_collections_api.py
@@ -203,12 +203,12 @@ async def test_update_collection_name_and_metadata() -> None:
     """PATCH should rename and/or update metadata properly."""
     async with get_async_test_client() as client:
         # create two collections
-        cola_info = await client.post(
+        await client.post(
             "/collections",
             json={"name": "colA", "metadata": {"a": 1}},
             headers=USER_1_HEADERS,
         )
-        colb_info = await client.post(
+        await client.post(
             "/collections",
             json={"name": "colB", "metadata": {"b": 2}},
             headers=USER_1_HEADERS,

--- a/tests/unit_tests/test_collections_api.py
+++ b/tests/unit_tests/test_collections_api.py
@@ -1,7 +1,5 @@
 from uuid import UUID
 
-import pytest
-
 from tests.unit_tests.fixtures import get_async_test_client
 
 USER_1_HEADERS = {
@@ -86,8 +84,8 @@ async def test_create_and_list_collection() -> None:
         assert any(c["name"] == "test_collection" for c in collections)
 
 
-async def test_create_collection_conflict() -> None:
-    """Creating a collection twice should return 409."""
+async def test_create_collections_with_identical_names() -> None:
+    """Test that collections with identical names can be created."""
     async with get_async_test_client() as client:
         payload = {"name": "dup_collection", "metadata": {"foo": "bar"}}
         # first create
@@ -96,8 +94,8 @@ async def test_create_collection_conflict() -> None:
 
         # second create with same name
         r2 = await client.post("/collections", json=payload, headers=USER_1_HEADERS)
-        assert r2.status_code == 409
-        assert "already exists" in r2.json()["detail"]
+        assert r2.status_code == 201
+        assert r1.json()["uuid"] != r2.json()["uuid"]
 
 
 async def test_create_collection_requires_auth() -> None:
@@ -201,19 +199,16 @@ async def test_patch_collection() -> None:
         }
 
 
-@pytest.mark.xfail(
-    reason="Need to fix representation of collections so a name is not unique."
-)
 async def test_update_collection_name_and_metadata() -> None:
     """PATCH should rename and/or update metadata properly."""
     async with get_async_test_client() as client:
         # create two collections
-        await client.post(
+        cola_info = await client.post(
             "/collections",
             json={"name": "colA", "metadata": {"a": 1}},
             headers=USER_1_HEADERS,
         )
-        await client.post(
+        colb_info = await client.post(
             "/collections",
             json={"name": "colB", "metadata": {"b": 2}},
             headers=USER_1_HEADERS,
@@ -227,12 +222,20 @@ async def test_update_collection_name_and_metadata() -> None:
         assert col_a_id is not None
 
         # try renaming colA to colB (conflict)
-        conflict = await client.patch(
+        no_conflict = await client.patch(
             f"/collections/{col_a_id}",
             json={"name": "colB"},
             headers=USER_1_HEADERS,
         )
-        assert conflict.status_code == 409
+        assert no_conflict.status_code == 200
+        assert no_conflict.json() == {
+            "metadata": {
+                "a": 1,
+                "owner_id": "user1",
+            },
+            "name": "colB",
+            "uuid": col_a_id,  # The ID should not change
+        }
 
         # rename colA to colC with new metadata (using the UUID we got earlier)
         update = await client.patch(
@@ -245,11 +248,8 @@ async def test_update_collection_name_and_metadata() -> None:
         assert body == {
             "uuid": body["uuid"],
             "name": "colC",
-            "metadata": {"x": "y"},
+            "metadata": {"x": "y", "owner_id": "user1"},
         }
-        # ensure old name is gone when querying by old name as ID
-        get_old = await client.get("/collections/colA")
-        assert get_old.status_code == 404
         # ensure we can get by the ID
         get_by_id = await client.get(f"/collections/{col_a_id}", headers=USER_1_HEADERS)
         assert get_by_id.status_code == 200
@@ -265,9 +265,9 @@ async def test_update_collection_name_and_metadata() -> None:
         )
         assert meta_update.status_code == 200
         assert meta_update.json() == {
-            "uuid": body["uuid"],
+            "uuid": col_a_id,
             "name": "colC",
-            "metadata": {"foo": "bar"},
+            "metadata": {"foo": "bar", "owner_id": "user1"},
         }
 
 


### PR DESCRIPTION
* This worksaround PGVector design issues to store the name in the metadata column.
* We'll remove the dependency on PGVector in a bit, but for now this should allow re-using a collection name across different users.