### PR TITLE
Add Naive Markdown support to document processing

### DIFF
--- a/langconnect/services/document_processor.py
+++ b/langconnect/services/document_processor.py
@@ -16,6 +16,7 @@ HANDLERS = {
     "application/pdf": PDFMinerParser(),
     "text/plain": TextParser(),
     "text/html": BS4HTMLParser(),
+    "text/markdown": TextParser(),
     "application/msword": MsWordParser(),
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document": (
         MsWordParser()


### PR DESCRIPTION
As the PR title says, markdown was missing from LangConnect support. Even though it could be better to use specific parsing for Markdown file, this adds a naive approach similar to other structured document types seen in the repo.