### PR TITLE
fix: restore lint checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,11 @@ celerybeat.pid
 
 # Environments
 .env
+.env.*
+*.pem
+*.key
+*.crt
+credentials.json
 .envrc
 .venv*
 venv*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ ignore = [
   "B904",
   "BLE001",
   "C901",
+  "CPY001",
   "D100",
   "D101",
   "D104",
@@ -127,4 +128,3 @@ ignore = [
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
-


### PR DESCRIPTION
Restores the lint gate by explicitly ignoring Ruff CPY001, which currently fails on existing files on both main and Dependabot PR #68. Also extends .gitignore coverage for common secret files.