### PR TITLE
fix: keep default allowed origins as a list

### DIFF
--- a/langconnect/config.py
+++ b/langconnect/config.py
@@ -46,5 +46,5 @@ if ALLOW_ORIGINS_JSON:
     ALLOWED_ORIGINS = json.loads(ALLOW_ORIGINS_JSON.strip())
     print(f"ALLOW_ORIGINS environment variable set to: {ALLOW_ORIGINS_JSON}")
 else:
-    ALLOWED_ORIGINS = "http://localhost:3000"
+    ALLOWED_ORIGINS = ["http://localhost:3000"]
     print("ALLOW_ORIGINS environment variable not set.")


### PR DESCRIPTION
## Description
Keep the default `ALLOWED_ORIGINS` value consistent with configured values by using a one-element list when `ALLOW_ORIGINS` is unset.

## Test Plan
- [x] Import config in testing mode and assert the default equals `["http://localhost:3000"]`
- [x] Run focused Ruff format and lint checks

Made by [Open SWE](https://openswe.vercel.app/agents/1e4b3bed-2dfb-c538-43cf-0bc8879e3dcd)